### PR TITLE
Uncomment constant definitions and add proper inline documentation.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -17,9 +17,33 @@
  */
 define( 'RESPONSIVE_CHILD_THEME_VERSION', '1.0.0' );
 
-// Layout selection
-// define( 'BU_RESPONSIVE_LAYOUT', 'default' );
+/**
+ * Specifies the responsive layout for the theme. Disables the option in the
+ * Customizer.
+ *
+ * Removing this allows the layout to be changed in the Customizer.
+ *
+ * Available values: `default`, `top-nav`, `side-nav`, `no-nav`.
+ *
+ * @link https://github.com/bu-ist/responsive-framework-documentation/blob/2x-documentation/code-examples/Changing-Available-Layouts-And-Default-Layout.md
+ */
+define( 'BU_RESPONSIVE_LAYOUT', 'default' );
 
-// Branding
-// define( 'BU_BRANDING_TYPE', 'logotype' );
+/**
+ * Specifies the site's branding type. Disables the option in the Customizer.
+ *
+ * Removing this allows the branding type to be changed in the Customizer.
+ *
+ * Available values: `logotype`, `signature`, `unbranded`.
+ */
+define( 'BU_BRANDING_TYPE', 'logotype' );
 
+/**
+ * Defines a sidebar position for the theme. Disables the option in the
+ * Customizer.
+ *
+ * Removing this allows the layout to be changed in the Customizer.
+ *
+ * Available values: `right`, `left`, `bottom`.
+ */
+define( 'BU_RESPONSIVE_SIDEBAR_POSITION', 'right' );


### PR DESCRIPTION
These constants are typically things we want controlled in child themes. Instead of including the constant definitions commented out in the child starter theme, let's uncomment them and specify the default Responsive Framework values. This allows us to add proper inline documentation educating developers and designers about these constants.

It also requires a deliberate action to take place to allow these options to be changeable in the Customizer, which is usually not the case in custom child themes.

Fixes #6.