### PR TITLE
Provide a license field in the `package.json` file. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "A starting point for Responsive Framework child themes.",
   "repository": "https://github.com/bu-ist/responsive-child-starter/",
-  "license": "GPL-2.0-or-later",
+  "license": "GPL-3.0-or-later",
   "contributors": [
     "Your Name <you@bu.edu>"
   ],

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "A starting point for Responsive Framework child themes.",
   "repository": "https://github.com/bu-ist/responsive-child-starter/",
-  "license": "GPL-2.0",
+  "license": "GPL-2.0-or-later",
   "contributors": [
     "Your Name <you@bu.edu>"
   ],

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "A starting point for Responsive Framework child themes.",
   "repository": "https://github.com/bu-ist/responsive-child-starter/",
+  "license": "GPL-2.0",
   "contributors": [
     "Your Name <you@bu.edu>"
   ],


### PR DESCRIPTION
NPM throws a warning when this is not defined.

Since we are a WordPress organization, we should use the GPL to follow the standards set by Core for the community.

A discussion happened about this in the [#web-team room in Slack](https://buweb.slack.com/archives/C08LCBE3D/p1523391311000230).

A few notes. `GPL-2.0-or-later` is the correct SPDX license (see the [SPDX documentation](https://spdx.org/licenses/)).

Running `npm install` now will produce a warning.

```
npm WARN responsive-child-starter@1.0.0 license should be a valid SPDX license expression
```

There is [an open issue about NPM improperly flagging this license as an invalid SPDX license expression](https://github.com/npm/npm/issues/19558). **TL;DR:** The GPL license names were changed in the most recent version of SPDX released in January of 2018. NPM needs to update to adhere to the new standards.

Fixes #21.