### PR TITLE
Add method to turn on all dev hooks

### DIFF
--- a/php-dev/dev-functions.php
+++ b/php-dev/dev-functions.php
@@ -115,6 +115,17 @@ function dev_sections() {
 		'r_before_closing_body_tag'         => false,
 	);
 
+	/**
+	 * Allow all hooks to be turned on via constant or filter.
+	 *
+	 * Default is false (no constant exists, and filter returns false).
+	 *
+	 * @since 2.2.3
+	 */
+	if ( ( defined( 'RESPONSIVE_ENABLE_ALL_DEV_HOOKS' ) && RESPONSIVE_ENABLE_ALL_DEV_HOOKS ) || apply_filters( 'responsive_enable_all_dev_hooks', false ) ) {
+		$hooks = array_map( '__return_true', $hooks );
+	}
+
 	global $hook_messages; // Global OK will only be used in development stage.
 	foreach ( $hooks as $hook => $include ) {
 		$git_url                = 'https://github.com/bu-ist/responsive-framework/search?q=' . $hook;


### PR DESCRIPTION
All dev hooks can be turned on via a RESPONSIVE_ENABLE_ALL_DEV_HOOKS constant with a truthy value, or the presense of a filter for `responsive_enable_all_dev_hooks` returning true.

Either of the following will enable all dev hooks by default:

```
// Adds a filter to enable all dev hooks. Place this in a theme file like functions.php.
add_filter( 'responsive_enable_all_dev_hooks', '__return_true' );

// Defines a constant to enable all dev hooks. Place this also in a theme file like functions.php or wp-config.php.
define( 'RESPONSIVE_ENABLE_ALL_DEV_HOOKS', true );
```